### PR TITLE
The $plugin_rel_path argument in load_plugin_textdomain() requires a trailing slash

### DIFF
--- a/message-board.php
+++ b/message-board.php
@@ -155,7 +155,7 @@ final class Message_Board {
 	 * @return void
 	 */
 	public function i18n() {
-		load_plugin_textdomain( 'message-board', false, 'message-board/languages' );
+		load_plugin_textdomain( 'message-board', false, 'message-board/languages/' );
 	}
 
 	public function register_views() {


### PR DESCRIPTION
As per: https://codex.wordpress.org/Function_Reference/load_plugin_textdomain

> $plugin_rel_path
> (string) (optional) Relative path to WP_PLUGIN_DIR, **with a trailing slash**. This is the preferred argument to use. It takes precendence over $abs_rel_path
